### PR TITLE
Fix erroring out on supported RBAC names with underscores

### DIFF
--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -91,10 +91,6 @@ func ParseObjMetadata(s string) (ObjMetadata, error) {
 	// Finally, second field name. Name may contain colon transcoded as double underscore.
 	name := s[:index]
 	name = strings.ReplaceAll(name, colonTranscoded, ":")
-	// Check that there are no extra fields by search for fieldSeparator.
-	if strings.Contains(name, fieldSeparator) {
-		return NilObjMetadata, fmt.Errorf("too many fields within: %s", s)
-	}
 	// Create the ObjMetadata object from the four parsed fields.
 	id := ObjMetadata{
 		Namespace: namespace,

--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -97,10 +97,29 @@ func TestParseObjMetadata(t *testing.T) {
 			inventory: &ObjMetadata{},
 			isError:   true,
 		},
-		"Too many fields": {
-			invStr:    "test-namespace_test-name_apps_foo_Deployment",
-			inventory: &ObjMetadata{},
-			isError:   true,
+		"Name can contain underscores": {
+			invStr: "test-namespace_test_name_apps_Deployment",
+			inventory: &ObjMetadata{
+				Namespace: "test-namespace",
+				Name:      "test_name",
+				GroupKind: schema.GroupKind{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+			},
+			isError: false,
+		},
+		"Name can contain multiple underscores": {
+			invStr: "test-namespace_test_name_with_underscores_apps_Deployment",
+			inventory: &ObjMetadata{
+				Namespace: "test-namespace",
+				Name:      "test_name_with_underscores",
+				GroupKind: schema.GroupKind{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+			},
+			isError: false,
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/fluxcd/kustomize-controller/issues/491

This PR resolves issues with parsing Kubernetes resources that contain underscores in their names, specifically addressing bugs encountered in the Flux kustomize-controller (related to issue #491).
### Key Changes

- Fix Resource Name Parsing: Removed the restrictive "too many fields" validation in ParseObjMetadata to allow resource names (like those often found in RBAC) to contain underscores.
- Expanded Test Coverage: Added unit tests to verify that ObjMetadata correctly parses names with single and multiple underscores.

